### PR TITLE
Fix: Grid generation loop excludes boundary cells

### DIFF
--- a/Engine.PathFinding.AStar/Grid.cs
+++ b/Engine.PathFinding.AStar/Grid.cs
@@ -68,9 +68,9 @@ namespace Engine.PathFinding.AStar
             float total = bbox.Size.X * bbox.Size.X / grid.Settings.NodeSize;
             int curr = 0;
 
-            for (float x = bbox.Minimum.X; x < bbox.Maximum.X; x += grid.Settings.NodeSize)
+            for (float x = bbox.Minimum.X; x <= bbox.Maximum.X; x += grid.Settings.NodeSize)
             {
-                for (float z = bbox.Minimum.Z; z < bbox.Maximum.Z; z += grid.Settings.NodeSize)
+                for (float z = bbox.Minimum.Z; z <= bbox.Maximum.Z; z += grid.Settings.NodeSize)
                 {
                     GridCollisionInfo[] info;
 


### PR DESCRIPTION
## Bug Description

The nested for loops in `Grid.CreateGrid` use `<` instead of `<=` for boundary conditions, causing the last row and column of grid cells to be skipped during grid generation.

## Impact

- Agents cannot pathfind to positions at the maximum X and Z coordinates of the bounding box
- Grid coverage is incomplete by one cell in both dimensions

## Fix

Changed both loop conditions from `<` to `<=`:
- `x < bbox.Maximum.X` → `x <= bbox.Maximum.X`
- `z < bbox.Maximum.Z` → `z <= bbox.Maximum.Z`

This ensures the boundary cells are included in the grid generation, providing complete coverage of the bounding box area.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.